### PR TITLE
fixed error on API call without parameters

### DIFF
--- a/src/Teepluss/Api/Api.php
+++ b/src/Teepluss/Api/Api.php
@@ -335,6 +335,11 @@ class Api {
 
             $parameters = current($parameters);
 
+			if ( !is_array($parameters) )
+			{
+				$parameters = array();
+			}
+
             if (preg_match('/^http(s)?/', $uri))
             {
                 return $this->invokeRemote($uri, $method, $parameters);


### PR DESCRIPTION
This addresses #8.

Internal request creation is failing when the $parameters array is set to false, which occurs when API:get() is called without a parameters array in the second parameter.
