### PR TITLE
Allow getOriginalContent to have an effect by using Response::make instead of Response::json

### DIFF
--- a/src/Teepluss/Api/Api.php
+++ b/src/Teepluss/Api/Api.php
@@ -208,7 +208,7 @@ class Api {
         // Header response.
         $header = ($this->config['httpResponse']) ? $code : 200;
 
-        return Response::json($response, $header);
+        return Response::make($response, $header);
     }
 
     /**


### PR DESCRIPTION
Right now, createResponse() uses Response::json to generate a formatted string as the final response. The problem with this is that when consuming the API using invoke(), $dispatch->getOriginalContent() never gets called, because the response being accessed was always just a string and was never assigned an original content object. Switching to Response::make preserves the existing functionality--the Response object still knows to convert everything to json before outputting to the browser, because of the header--but it also preserves the response array set in make(). All this REALLY means is that invoke() can pull the response array directly from getOriginalContent(), and doesn't have to json_decode the formatted string. However, that seems like a worthwhile savings.
