### PR TITLE
Allow empty data (configurable) in response

### DIFF
--- a/src/Teepluss/Api/Api.php
+++ b/src/Teepluss/Api/Api.php
@@ -200,7 +200,7 @@ class Api {
             });
 
             // Remove empty data.
-            if (empty($response['data']))
+            if ($this->config['removeEmptyData'] && empty($response['data']))
             {
                 unset($response['data']);
             }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,6 +12,6 @@ return array(
     |
     */
 
-    'httpResponse' => false
-
+    'httpResponse' => false,
+    'removeEmptyData' => true
 );


### PR DESCRIPTION
Hi,

For my current project I needed a way to return a empty array. 
The empty data parameter is removed by default. I made some minor changes to make the feature configurable.
