### PR TITLE
Update dependency for Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.x",
-        "guzzle/guzzle": "3.9.1"
+        "guzzle/guzzle": "3.9.x"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2"


### PR DESCRIPTION
You wont be able to install this package in many scenarios if there is dependency to specific Guzzle version.
